### PR TITLE
Migrate to tidyverse

### DIFF
--- a/Rpopgen/Dockerfile
+++ b/Rpopgen/Dockerfile
@@ -4,12 +4,6 @@
 FROM rocker/hadleyverse
 MAINTAINER Hilmar Lapp hilmar.lapp@duke.edu
 
-## Fixed upstream: https://github.com/rocker-org/hadleyverse/commit/3357bf2631c84b0875e0f04642beda01ba85191b
-## OpenBLAS is having some issues at the moment, this installs Atlas BLAS
-## RUN apt-get update \
-## &&  apt-get remove -y libopenblas-base \
-## &&  apt-get install -y libatlas-base-dev
-
 ## Bioconductor dependencies of packages we install from CRAN (specifically pegas)
 RUN Rscript -e 'source("http://bioconductor.org/biocLite.R"); biocLite("Biostrings");'
 

--- a/Rpopgen/Dockerfile
+++ b/Rpopgen/Dockerfile
@@ -4,6 +4,11 @@
 FROM rocker/tidyverse:latest
 MAINTAINER Hilmar Lapp hilmar.lapp@duke.edu
 
+## Some of the R packages depend on package gsl, which requires gsl-dev
+## to be installed in order to succeed
+RUN apt-get update \
+    && apt-get install -y libgsl0-dev
+ 
 ## Bioconductor dependencies of packages we install from CRAN (specifically pegas)
 RUN Rscript -e 'source("http://bioconductor.org/biocLite.R"); biocLite("Biostrings");'
 

--- a/Rpopgen/Dockerfile
+++ b/Rpopgen/Dockerfile
@@ -1,7 +1,7 @@
 ## Start with the hadleyverse image from Rocker, then add population
 ## genetics images on top.
 
-FROM rocker/hadleyverse
+FROM rocker/tidyverse:latest
 MAINTAINER Hilmar Lapp hilmar.lapp@duke.edu
 
 ## Bioconductor dependencies of packages we install from CRAN (specifically pegas)


### PR DESCRIPTION
Apparently rocker/hadleyverse is now being phased out in favor of tidyverse. Also, hopefully this change gets rid of the build issues on Docker Hub; at least it builds successfully locally. See the following for some discussion and context: rocker-org/hadleyverse@24866c2cd62927250c1e01f0aef84e7fa919f9bc