### PR TITLE
Moves pcadapt to being installed from CRAN again

### DIFF
--- a/Rpopgen/Dockerfile
+++ b/Rpopgen/Dockerfile
@@ -46,6 +46,7 @@ RUN rm -rf /tmp/*.rds \
     multcomp \
     raster \
     viridis \
+    pcadapt \
 && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
 
 ## Bioconductor packages (they may be dependencies)
@@ -55,7 +56,6 @@ RUN Rscript -e 'source("http://bioconductor.org/biocLite.R"); biocLite("qvalue")
 ## (hierfstat included here temporarily until new release is on CRAN)
 RUN installGithub.r \
     whitlock/OutFLANK \
-    bcm-uga/pcadapt \
 && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
 
 ## Install other useful packages from CRAN


### PR DESCRIPTION
Currently pcadapt has a dependency on rmio, which is not on CRAN (yet?), and is missing its repo in the `Remotes` declaration. See #29 and #23.