### PR TITLE
Ties the base image to a tag using R v3.5.2

### DIFF
--- a/Rpopgen/Dockerfile
+++ b/Rpopgen/Dockerfile
@@ -1,7 +1,7 @@
 ## Start with the hadleyverse image from Rocker, then add population
 ## genetics images on top.
 
-FROM rocker/tidyverse:latest
+FROM rocker/tidyverse:3.5.2
 MAINTAINER Hilmar Lapp hilmar.lapp@duke.edu
 
 # Prevent error messages from debconf about non-interactive frontend


### PR DESCRIPTION
The immediate motivation for this is to fix the apparent unavailability of quadprog (a dependency of phangorn) in R v3.5.3, the version of R used in the `latest` tag. However, see #20 and #32 for context.

Closes #32.